### PR TITLE
feat(api): add directory initialization on startup

### DIFF
--- a/MelonService/Dockerfile
+++ b/MelonService/Dockerfile
@@ -31,8 +31,8 @@ RUN if [ -f "Source/Core/Base/Builders/MangaBuilder.py" ]; then \
     echo "Cross-device link patch applied"; \
 fi
 
-# Создаем необходимые директории
-RUN mkdir -p Output/mangalib/titles Output/mangalib/archives Output/mangalib/images Logs Temp
+# Создаем необходимые директории (НЕ создаем Logs, Temp, Output - они будут volumes)
+RUN mkdir -p /tmp/init
 
 # Открываем порт для API
 EXPOSE 8084

--- a/MelonService/Dockerfile.dev
+++ b/MelonService/Dockerfile.dev
@@ -25,8 +25,8 @@ RUN if [ -f "dublib/Methods/Filesystem.py" ]; then \
     echo "UTF-8 patch applied"; \
 fi
 
-# Создаем необходимые директории
-RUN mkdir -p Output/mangalib/titles Output/mangalib/archives Output/mangalib/images Logs Temp
+# Создаем необходимые директории (НЕ создаем Logs, Temp, Output - они будут volumes)
+RUN mkdir -p /tmp/init
 
 # Открываем порт для API
 EXPOSE 8084

--- a/MelonService/api_server.py
+++ b/MelonService/api_server.py
@@ -98,6 +98,39 @@ def ensure_utf8_patch():
             dublib_path.write_text(content, encoding='utf-8')
             logger.info("UTF-8 patch applied successfully")
 
+def ensure_directories():
+    """Создает необходимые директории для работы приложения только если они не существуют"""
+    base_path = get_melon_base_path()
+    
+    # Создаем основные директории
+    directories = [
+        base_path / "Output",
+        base_path / "Output" / "mangalib" / "titles",
+        base_path / "Output" / "mangalib" / "archives", 
+        base_path / "Output" / "mangalib" / "images",
+        base_path / "Logs",
+        base_path / "Temp"
+    ]
+    
+    for directory in directories:
+        try:
+            if directory.exists():
+                logger.info(f"Directory already exists: {directory}")
+            else:
+                directory.mkdir(parents=True, exist_ok=True)
+                logger.info(f"Directory created: {directory}")
+        except Exception as e:
+            logger.error(f"Failed to create directory {directory}: {e}")
+
+# Инициализация при старте приложения
+@app.on_event("startup")
+async def startup_event():
+    """Инициализация при старте приложения"""
+    logger.info("Starting MelonService API...")
+    ensure_directories()
+    ensure_utf8_patch()
+    logger.info("MelonService API startup completed")
+
 def ensure_cross_device_patch():
     """Исправляет ошибку 'Invalid cross-device link' в MangaBuilder"""
     builder_path = get_melon_base_path() / "Parsers" / "MangaBuilder.py"


### PR DESCRIPTION
This pull request refactors how required directories are created for the MelonService application. Instead of creating directories in the Dockerfiles, the logic is now moved into the application code to ensure proper initialization at startup. This makes the directory management more robust and compatible with Docker volumes.

**Directory management improvements:**

* Added a new `ensure_directories` function in `api_server.py` to create necessary directories (`Output`, `Logs`, `Temp`, and subdirectories) only if they don't exist, improving reliability and logging.
* Registered an application startup event in `api_server.py` to automatically initialize directories and apply the UTF-8 patch when the API server starts.

**Dockerfile changes:**

* Updated both `Dockerfile` and `Dockerfile.dev` to stop creating `Logs`, `Temp`, and `Output` directories, since these will now be managed as Docker volumes and initialized by the application itself. Instead, a placeholder `/tmp/init` directory is created to maintain Docker build consistency. [[1]](diffhunk://#diff-dfab05633176dd60572564e4b62ce9e5ea928e7a7e8347a09a904b2eb079dd73L34-R35) [[2]](diffhunk://#diff-3f545e11940fde3430512b4fde50d20cd329f5c0fc3626d28fc8af1af6b63334L28-R29)