### PR TITLE
feat(api): refine directory initialization to create subdirectories w…

### DIFF
--- a/MelonService/Dockerfile
+++ b/MelonService/Dockerfile
@@ -31,9 +31,6 @@ RUN if [ -f "Source/Core/Base/Builders/MangaBuilder.py" ]; then \
     echo "Cross-device link patch applied"; \
 fi
 
-# Создаем необходимые директории (НЕ создаем Logs, Temp, Output - они будут volumes)
-RUN mkdir -p /tmp/init
-
 # Открываем порт для API
 EXPOSE 8084
 

--- a/MelonService/Dockerfile.dev
+++ b/MelonService/Dockerfile.dev
@@ -25,9 +25,6 @@ RUN if [ -f "dublib/Methods/Filesystem.py" ]; then \
     echo "UTF-8 patch applied"; \
 fi
 
-# Создаем необходимые директории (НЕ создаем Logs, Temp, Output - они будут volumes)
-RUN mkdir -p /tmp/init
-
 # Открываем порт для API
 EXPOSE 8084
 

--- a/MelonService/api_server.py
+++ b/MelonService/api_server.py
@@ -99,20 +99,19 @@ def ensure_utf8_patch():
             logger.info("UTF-8 patch applied successfully")
 
 def ensure_directories():
-    """Создает необходимые директории для работы приложения только если они не существуют"""
+    """Создает необходимые поддиректории внутри уже смонтированных volumes"""
     base_path = get_melon_base_path()
     
-    # Создаем основные директории
-    directories = [
-        base_path / "Output",
+    # Создаем только поддиректории внутри уже смонтированных volumes
+    # Output, Logs, Temp будут созданы Docker как mount points
+    subdirectories = [
+        base_path / "Output" / "mangalib",
         base_path / "Output" / "mangalib" / "titles",
         base_path / "Output" / "mangalib" / "archives", 
-        base_path / "Output" / "mangalib" / "images",
-        base_path / "Logs",
-        base_path / "Temp"
+        base_path / "Output" / "mangalib" / "images"
     ]
     
-    for directory in directories:
+    for directory in subdirectories:
         try:
             if directory.exists():
                 logger.info(f"Directory already exists: {directory}")
@@ -121,6 +120,19 @@ def ensure_directories():
                 logger.info(f"Directory created: {directory}")
         except Exception as e:
             logger.error(f"Failed to create directory {directory}: {e}")
+    
+    # Проверяем, что основные volume директории доступны
+    main_volumes = [
+        base_path / "Output",
+        base_path / "Logs", 
+        base_path / "Temp"
+    ]
+    
+    for volume_dir in main_volumes:
+        if volume_dir.exists() and volume_dir.is_dir():
+            logger.info(f"Volume directory is accessible: {volume_dir}")
+        else:
+            logger.warning(f"Volume directory not accessible: {volume_dir}")
 
 # Инициализация при старте приложения
 @app.on_event("startup")


### PR DESCRIPTION
This pull request refactors the directory creation logic to better support Docker volume mounts and clarifies the responsibilities between Docker and the application for managing directories. The main changes are focused on ensuring that only necessary subdirectories are created by the application, while the main directories are expected to be provided by Docker as volumes. Additionally, the code now checks that these main volume directories are accessible at runtime.

**Directory management improvements:**

* Refactored the `ensure_directories` function in `api_server.py` to only create subdirectories inside already mounted Docker volumes, rather than creating the main `Output`, `Logs`, and `Temp` directories. These main directories are now expected to be managed by Docker as mount points.
* Added runtime checks to verify that the main volume directories (`Output`, `Logs`, `Temp`) are accessible, with appropriate logging for their status.

**Dockerfile cleanup:**

* Removed commands in both `Dockerfile` and `Dockerfile.dev` that previously created the `/tmp/init` directory, since main directories are now handled as Docker volumes and not created by the build process. [[1]](diffhunk://#diff-dfab05633176dd60572564e4b62ce9e5ea928e7a7e8347a09a904b2eb079dd73L34-L36) [[2]](diffhunk://#diff-3f545e11940fde3430512b4fde50d20cd329f5c0fc3626d28fc8af1af6b63334L28-L30)