### PR TITLE
feat(docker): update volume mounts to use individual files and direct…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -127,7 +127,15 @@ services:
     ports:
       - "8084:8084"
     volumes:
-      - ./MelonService:/app:ro
+      # Монтируем отдельные файлы/папки вместо всего /app
+      - ./MelonService/api_server.py:/app/api_server.py:ro
+      - ./MelonService/main.py:/app/main.py:ro
+      - ./MelonService/requirements.txt:/app/requirements.txt:ro
+      - ./MelonService/Source:/app/Source:ro
+      - ./MelonService/Parsers:/app/Parsers:ro
+      - ./MelonService/Templates:/app/Templates:ro
+      - ./MelonService/Docs:/app/Docs:ro
+      # Volume директории (НЕ read-only)
       - melon_data:/app/Output
       - melon_logs:/app/Logs
       - melon_temp:/app/Temp


### PR DESCRIPTION
This pull request updates the volume mounts for the `MelonService` in the `docker-compose.dev.yml` file to improve development workflow and container management. Instead of mounting the entire `MelonService` directory as read-only, it now mounts individual files and folders, allowing for more granular control and potentially reducing issues with unnecessary file exposure.

Improvements to Docker volume management:

* Changed the volume mounts for `MelonService` to individually mount key files (`api_server.py`, `main.py`, `requirements.txt`) and folders (`Source`, `Parsers`, `Templates`, `Docs`) as read-only, rather than mounting the entire directory.
* Retained writable volume mounts for output, logs, and temporary data directories to ensure proper service operation.