### PR TITLE
feat(docker): refactor volume mounts and update base path for develop…

### DIFF
--- a/MelonService/Dockerfile.dev
+++ b/MelonService/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /app
+WORKDIR /app/src
 
 # Устанавливаем системные зависимости
 RUN apt-get update && apt-get install -y \
@@ -24,6 +24,9 @@ RUN if [ -f "dublib/Methods/Filesystem.py" ]; then \
     sed -i 's/open(path, "w")/open(path, "w", encoding="utf-8")/g' dublib/Methods/Filesystem.py; \
     echo "UTF-8 patch applied"; \
 fi
+
+# Создаем директории для данных
+RUN mkdir -p /data
 
 # Открываем порт для API
 EXPOSE 8084

--- a/MelonService/api_server.py
+++ b/MelonService/api_server.py
@@ -80,7 +80,9 @@ build_states: Dict[str, Dict[str, Any]] = {}  # task_id -> {"slug": str, "is_rea
 
 # Вспомогательные функции
 def get_melon_base_path() -> Path:
-    return Path("/app")
+    # В dev режиме volumes монтируются в /data, в prod - в /app
+    base_path = os.getenv('MELON_BASE_PATH', '/app')
+    return Path(base_path)
 
 def ensure_utf8_patch():
     """Применяет критический патч для UTF-8 кодировки"""

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -127,20 +127,15 @@ services:
     ports:
       - "8084:8084"
     volumes:
-      # Монтируем отдельные файлы/папки вместо всего /app
-      - ./MelonService/api_server.py:/app/api_server.py:ro
-      - ./MelonService/main.py:/app/main.py:ro
-      - ./MelonService/requirements.txt:/app/requirements.txt:ro
-      - ./MelonService/Source:/app/Source:ro
-      - ./MelonService/Parsers:/app/Parsers:ro
-      - ./MelonService/Templates:/app/Templates:ro
-      - ./MelonService/Docs:/app/Docs:ro
-      # Volume директории (НЕ read-only)
-      - melon_data:/app/Output
-      - melon_logs:/app/Logs
-      - melon_temp:/app/Temp
+      # Монтируем исходный код (без read-only для volume compatibility)
+      - ./MelonService:/app/src
+      # Volume директории в другом месте
+      - melon_data:/data/Output
+      - melon_logs:/data/Logs
+      - melon_temp:/data/Temp
     environment:
-      - PYTHONPATH=/app
+      - PYTHONPATH=/app/src
+      - MELON_BASE_PATH=/data
     networks:
       - aniway-network
     restart: unless-stopped


### PR DESCRIPTION
This pull request updates the development environment setup for the MelonService to improve volume management and make the application more flexible between development and production. The main changes include restructuring the working directory, updating volume mounts, and introducing a configurable base path for data storage.

**Dockerfile and Compose improvements:**

* Changed the working directory in `Dockerfile.dev` from `/app` to `/app/src` to better separate source code from data and dependencies.
* Updated `docker-compose.dev.yml` to mount the entire `MelonService` directory to `/app/src` and moved data-related volumes (`Output`, `Logs`, `Temp`) to `/data` instead of `/app`, improving compatibility and organization.
* Added creation of the `/data` directory in `Dockerfile.dev` to ensure the new data volume paths exist at container startup.

**Configuration and environment variables:**

* Introduced the `MELON_BASE_PATH` environment variable, allowing the base path for data storage to be configurable (defaulting to `/app` but set to `/data` in development). Updated the `get_melon_base_path` helper in `api_server.py` to use this variable. [[1]](diffhunk://#diff-936c7ab02825bde4061d01041f7b566af085a0c50b9e317a79ffb9b3f54539ddL83-R85) [[2]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1L130-R138)
* Updated `PYTHONPATH` to `/app/src` in `docker-compose.dev.yml` to reflect the new source code location.