### PR TITLE
feat(docker): simplify volume paths and ensure necessary directories …

### DIFF
--- a/MelonService/Dockerfile
+++ b/MelonService/Dockerfile
@@ -31,6 +31,9 @@ RUN if [ -f "Source/Core/Base/Builders/MangaBuilder.py" ]; then \
     echo "Cross-device link patch applied"; \
 fi
 
+# Создаем необходимые директории
+RUN mkdir -p Output/mangalib/titles Output/mangalib/archives Output/mangalib/images Logs Temp
+
 # Открываем порт для API
 EXPOSE 8084
 

--- a/MelonService/Dockerfile.dev
+++ b/MelonService/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /app/src
+WORKDIR /app
 
 # Устанавливаем системные зависимости
 RUN apt-get update && apt-get install -y \
@@ -25,8 +25,8 @@ RUN if [ -f "dublib/Methods/Filesystem.py" ]; then \
     echo "UTF-8 patch applied"; \
 fi
 
-# Создаем директории для данных
-RUN mkdir -p /data
+# Создаем необходимые директории
+RUN mkdir -p Output/mangalib/titles Output/mangalib/archives Output/mangalib/images Logs Temp
 
 # Открываем порт для API
 EXPOSE 8084

--- a/MelonService/api_server.py
+++ b/MelonService/api_server.py
@@ -80,9 +80,7 @@ build_states: Dict[str, Dict[str, Any]] = {}  # task_id -> {"slug": str, "is_rea
 
 # Вспомогательные функции
 def get_melon_base_path() -> Path:
-    # В dev режиме volumes монтируются в /data, в prod - в /app
-    base_path = os.getenv('MELON_BASE_PATH', '/app')
-    return Path(base_path)
+    return Path("/app")
 
 def ensure_utf8_patch():
     """Применяет критический патч для UTF-8 кодировки"""
@@ -99,51 +97,6 @@ def ensure_utf8_patch():
             )
             dublib_path.write_text(content, encoding='utf-8')
             logger.info("UTF-8 patch applied successfully")
-
-def ensure_directories():
-    """Создает необходимые поддиректории внутри уже смонтированных volumes"""
-    base_path = get_melon_base_path()
-    
-    # Создаем только поддиректории внутри уже смонтированных volumes
-    # Output, Logs, Temp будут созданы Docker как mount points
-    subdirectories = [
-        base_path / "Output" / "mangalib",
-        base_path / "Output" / "mangalib" / "titles",
-        base_path / "Output" / "mangalib" / "archives", 
-        base_path / "Output" / "mangalib" / "images"
-    ]
-    
-    for directory in subdirectories:
-        try:
-            if directory.exists():
-                logger.info(f"Directory already exists: {directory}")
-            else:
-                directory.mkdir(parents=True, exist_ok=True)
-                logger.info(f"Directory created: {directory}")
-        except Exception as e:
-            logger.error(f"Failed to create directory {directory}: {e}")
-    
-    # Проверяем, что основные volume директории доступны
-    main_volumes = [
-        base_path / "Output",
-        base_path / "Logs", 
-        base_path / "Temp"
-    ]
-    
-    for volume_dir in main_volumes:
-        if volume_dir.exists() and volume_dir.is_dir():
-            logger.info(f"Volume directory is accessible: {volume_dir}")
-        else:
-            logger.warning(f"Volume directory not accessible: {volume_dir}")
-
-# Инициализация при старте приложения
-@app.on_event("startup")
-async def startup_event():
-    """Инициализация при старте приложения"""
-    logger.info("Starting MelonService API...")
-    ensure_directories()
-    ensure_utf8_patch()
-    logger.info("MelonService API startup completed")
 
 def ensure_cross_device_patch():
     """Исправляет ошибку 'Invalid cross-device link' в MangaBuilder"""

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -127,15 +127,12 @@ services:
     ports:
       - "8084:8084"
     volumes:
-      # Монтируем исходный код (без read-only для volume compatibility)
-      - ./MelonService:/app/src
-      # Volume директории в другом месте
-      - melon_data:/data/Output
-      - melon_logs:/data/Logs
-      - melon_temp:/data/Temp
+      - ./MelonService:/app
+      - melon_data:/app/Output
+      - melon_logs:/app/Logs
+      - melon_temp:/app/Temp
     environment:
-      - PYTHONPATH=/app/src
-      - MELON_BASE_PATH=/data
+      - PYTHONPATH=/app
     networks:
       - aniway-network
     restart: unless-stopped


### PR DESCRIPTION
This pull request updates the directory structure and volume mounting approach for the MelonService application, simplifying both the Docker configuration and the application initialization logic. The changes ensure consistency between development and production environments, centralize data directories under `/app`, and remove redundant directory initialization code from the application itself.

**Docker configuration and directory structure:**

* Updated the working directory in `Dockerfile.dev` and `docker-compose.dev.yml` from `/app/src` to `/app`, and adjusted volume mounts so that all data, logs, and temp directories are under `/app` instead of `/data`. This simplifies the environment and eliminates confusion between dev and prod setups. [[1]](diffhunk://#diff-3f545e11940fde3430512b4fde50d20cd329f5c0fc3626d28fc8af1af6b63334L3-R3) [[2]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1L130-R135)
* Added commands in both `Dockerfile` and `Dockerfile.dev` to create necessary subdirectories (`Output/mangalib/titles`, `Output/mangalib/archives`, `Output/mangalib/images`, `Logs`, `Temp`) during image build, ensuring all required folders exist before the application starts. [[1]](diffhunk://#diff-dfab05633176dd60572564e4b62ce9e5ea928e7a7e8347a09a904b2eb079dd73R34-R36) [[2]](diffhunk://#diff-3f545e11940fde3430512b4fde50d20cd329f5c0fc3626d28fc8af1af6b63334L28-R29)

**Application initialization logic:**

* Removed the `ensure_directories()` function and related startup event logic from `api_server.py`, since directory creation is now handled by Docker during image build, reducing startup complexity and potential race conditions.
* Simplified the `get_melon_base_path()` function to always return `/app`, reflecting the new standardized directory structure and removing environment variable dependencies.