### PR TITLE
remove subtitle descriptions from CatalogPage and LibraryPage headers

### DIFF
--- a/AniWayFrontend/src/pages/CatalogPage.tsx
+++ b/AniWayFrontend/src/pages/CatalogPage.tsx
@@ -71,9 +71,6 @@ export function CatalogPage() {
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-white mb-2 bg-gradient-to-r from-white to-muted-foreground bg-clip-text text-transparent">
               {pageTitle}
             </h1>
-            <p className="text-muted-foreground text-sm md:text-base">
-              Открывайте для себя новые истории
-            </p>
           </div>
         </div>
 

--- a/AniWayFrontend/src/pages/LibraryPage.tsx
+++ b/AniWayFrontend/src/pages/LibraryPage.tsx
@@ -172,9 +172,6 @@ export const LibraryPage: React.FC = () => {
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-white mb-2 bg-gradient-to-r from-white to-muted-foreground bg-clip-text text-transparent">
               Моя библиотека
             </h1>
-            <p className="text-muted-foreground text-sm md:text-base">
-              Управляйте своими закладками и отслеживайте прогресс чтения
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
This pull request makes small UI adjustments to the `CatalogPage` and `LibraryPage` by removing the subtitle text under the main page titles. This results in a cleaner header section on both pages.

- Removed the subtitle "Открывайте для себя новые истории" from under the main title in `CatalogPage.tsx`.
- Removed the subtitle "Управляйте своими закладками и отслеживайте прогресс чтения" from under the main title in `LibraryPage.tsx`.