### PR TITLE
add manga view and unique view counters with backend rate limiting an…

### DIFF
--- a/AniWayFrontend/src/components/manga/MangaCard.tsx
+++ b/AniWayFrontend/src/components/manga/MangaCard.tsx
@@ -27,7 +27,8 @@ export function MangaCard({ manga, size = 'default', showMetadata = true }: Mang
   }
 
   // Генерируем фейковые просмотры для демонстрации (в реальном проекте это будет из API)
-  const views = Math.floor(Math.random() * 10000) + 1000
+  const views = manga.views || 0
+  const uniqueViews = manga.uniqueViews || 0
 
   // Получаем статус закладки
   const bookmarkInfo = isAuthenticated ? getMangaBookmark(manga.id) : null
@@ -176,6 +177,11 @@ export function MangaCard({ manga, size = 'default', showMetadata = true }: Mang
                 <Eye className="h-2.5 w-2.5 md:h-3 md:w-3" />
                 <span className="hidden sm:inline">{views.toLocaleString()}</span>
                 <span className="sm:hidden">{(views / 1000).toFixed(0)}k</span>
+              </div>
+              <div className="flex items-center space-x-1">
+                <Heart className="h-2.5 w-2.5 md:h-3 md:w-3" />
+                <span className="hidden sm:inline">{uniqueViews.toLocaleString()}</span>
+                <span className="sm:hidden">{(uniqueViews / 1000).toFixed(0)}k</span>
               </div>
             </div>
           </div>

--- a/AniWayFrontend/src/lib/api.ts
+++ b/AniWayFrontend/src/lib/api.ts
@@ -70,6 +70,12 @@ class ApiClient {
     return this.request<ChapterDTO[]>(`/manga/${mangaId}/chapters`);
   }
 
+  async incrementMangaView(mangaId: number): Promise<void> {
+    await this.request<void>(`/manga/${mangaId}/view`, {
+      method: 'POST',
+    });
+  }
+
   // Chapter API
   async getChapterById(id: number): Promise<ChapterDTO> {
     return this.request<ChapterDTO>(`/chapters/${id}`);

--- a/AniWayFrontend/src/pages/MangaPage.tsx
+++ b/AniWayFrontend/src/pages/MangaPage.tsx
@@ -49,6 +49,17 @@ export function MangaPage() {
     enabled: !!mangaId,
   })
 
+  // Increment view count when manga data is loaded
+  useEffect(() => {
+    if (manga && !mangaLoading) {
+      // Increment view count (this will be rate-limited on the backend)
+      apiClient.incrementMangaView(mangaId).catch((error) => {
+        // Silently handle errors to avoid disrupting the user experience
+        console.warn('Failed to increment view count:', error)
+      })
+    }
+  }, [manga, mangaLoading, mangaId])
+
   const { isChapterCompleted } = useReadingProgress()
 
   if (mangaLoading) {
@@ -197,6 +208,19 @@ export function MangaPage() {
                 {/* Title */}
                 <div className="text-center lg:text-left">
                   <h1 className="text-xl md:text-2xl font-bold text-white mb-2">{manga.title}</h1>
+                  
+                  {/* View Counters */}
+                  <div className="flex items-center justify-center lg:justify-start gap-4 mb-3">
+                    <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                      <Eye className="h-4 w-4" />
+                      <span>{(manga.views || 0).toLocaleString()}</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                      <Heart className="h-4 w-4" />
+                      <span>{(manga.uniqueViews || 0).toLocaleString()}</span>
+                    </div>
+                  </div>
+                  
                   {/* Mobile - Type and Year after title */}
                   <div className="lg:hidden flex items-center justify-center gap-3 text-sm text-muted-foreground">
                     <span>{getTypeDisplay(manga.type)}</span>

--- a/AniWayFrontend/src/types/index.ts
+++ b/AniWayFrontend/src/types/index.ts
@@ -17,6 +17,8 @@ export interface MangaResponseDTO {
   coverImageUrl: string
   chapterCount: number
   totalChapters: number
+  views: number
+  uniqueViews: number
   createdAt: string
   updatedAt: string
 }

--- a/MangaService/build.gradle.kts
+++ b/MangaService/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework:spring-websocket")
     implementation("org.springframework:spring-messaging")

--- a/MangaService/src/main/java/shadowshift/studio/mangaservice/config/CacheConfig.java
+++ b/MangaService/src/main/java/shadowshift/studio/mangaservice/config/CacheConfig.java
@@ -27,7 +27,9 @@ public class CacheConfig {
      */
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(
+            "mangaCatalog", "mangaSearch", "mangaDetails", "mangaChapters", "userMangaView"
+        );
 
         // Настройка кэша для списка манг (каталог)
         cacheManager.setCaffeine(Caffeine.newBuilder()

--- a/MangaService/src/main/java/shadowshift/studio/mangaservice/dto/MangaResponseDTO.java
+++ b/MangaService/src/main/java/shadowshift/studio/mangaservice/dto/MangaResponseDTO.java
@@ -93,6 +93,16 @@ public class MangaResponseDTO {
     private Integer totalChapters;
 
     /**
+     * Общее количество просмотров манги.
+     */
+    private Long views;
+
+    /**
+     * Количество уникальных просмотров манги.
+     */
+    private Long uniqueViews;
+
+    /**
      * Дата создания записи о манге.
      */
     private LocalDateTime createdAt;
@@ -129,6 +139,8 @@ public class MangaResponseDTO {
         this.isLicensed = manga.getIsLicensed();
         this.coverImageUrl = manga.getCoverImageUrl();
         this.totalChapters = manga.getTotalChapters();
+        this.views = manga.getViews();
+        this.uniqueViews = manga.getUniqueViews();
         this.createdAt = manga.getCreatedAt();
         this.updatedAt = manga.getUpdatedAt();
     }
@@ -356,6 +368,34 @@ public class MangaResponseDTO {
      * @param totalChapters общее количество глав
      */
     public void setTotalChapters(Integer totalChapters) { this.totalChapters = totalChapters; }
+
+    /**
+     * Возвращает общее количество просмотров манги.
+     *
+     * @return количество просмотров
+     */
+    public Long getViews() { return views; }
+
+    /**
+     * Устанавливает общее количество просмотров манги.
+     *
+     * @param views количество просмотров
+     */
+    public void setViews(Long views) { this.views = views; }
+
+    /**
+     * Возвращает количество уникальных просмотров манги.
+     *
+     * @return количество уникальных просмотров
+     */
+    public Long getUniqueViews() { return uniqueViews; }
+
+    /**
+     * Устанавливает количество уникальных просмотров манги.
+     *
+     * @param uniqueViews количество уникальных просмотров
+     */
+    public void setUniqueViews(Long uniqueViews) { this.uniqueViews = uniqueViews; }
 
     /**
      * Возвращает дату создания записи о манге.

--- a/MangaService/src/main/java/shadowshift/studio/mangaservice/entity/Manga.java
+++ b/MangaService/src/main/java/shadowshift/studio/mangaservice/entity/Manga.java
@@ -130,6 +130,18 @@ public class Manga {
     private LocalDateTime updatedAt;
 
     /**
+     * Общее количество просмотров манги.
+     */
+    @Column(name = "views")
+    private Long views = 0L;
+
+    /**
+     * Количество уникальных просмотров манги (с rate limiting).
+     */
+    @Column(name = "unique_views")
+    private Long uniqueViews = 0L;
+
+    /**
      * Метод, вызываемый перед сохранением сущности.
      * Устанавливает даты создания и обновления.
      */
@@ -417,6 +429,34 @@ public class Manga {
      * @param isLicensed флаг лицензированности
      */
     public void setIsLicensed(Boolean isLicensed) { this.isLicensed = isLicensed; }
+
+    /**
+     * Возвращает общее количество просмотров манги.
+     *
+     * @return количество просмотров
+     */
+    public Long getViews() { return views; }
+
+    /**
+     * Устанавливает общее количество просмотров манги.
+     *
+     * @param views количество просмотров
+     */
+    public void setViews(Long views) { this.views = views; }
+
+    /**
+     * Возвращает количество уникальных просмотров манги.
+     *
+     * @return количество уникальных просмотров
+     */
+    public Long getUniqueViews() { return uniqueViews; }
+
+    /**
+     * Устанавливает количество уникальных просмотров манги.
+     *
+     * @param uniqueViews количество уникальных просмотров
+     */
+    public void setUniqueViews(Long uniqueViews) { this.uniqueViews = uniqueViews; }
 
     /**
      * Перечисление статусов манги.

--- a/MangaService/src/main/java/shadowshift/studio/mangaservice/service/ViewTrackingService.java
+++ b/MangaService/src/main/java/shadowshift/studio/mangaservice/service/ViewTrackingService.java
@@ -1,0 +1,54 @@
+package shadowshift.studio.mangaservice.service;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Сервис для отслеживания просмотров манги с rate limiting.
+ * Управляет счетчиками просмотров и предотвращает накрутку просмотров одним пользователем.
+ *
+ * @author ShadowShiftStudio
+ */
+@Service
+public class ViewTrackingService {
+
+    /**
+     * Проверяет, может ли пользователь увеличить уникальный счетчик просмотров.
+     * Использует кэш для хранения времени последнего просмотра.
+     *
+     * @param userId идентификатор пользователя
+     * @param mangaId идентификатор манги
+     * @return true, если можно увеличить уникальный счетчик, false - если rate limit активен
+     */
+    @Cacheable(value = "userMangaView", key = "#userId + '_' + #mangaId")
+    public Boolean canIncrementUniqueView(String userId, Long mangaId) {
+        // Если значение в кэше отсутствует, значит пользователь еще не смотрел эту мангу
+        // Возвращаем true, чтобы разрешить увеличение счетчика
+        return true;
+    }
+
+    /**
+     * Вычисляет время до истечения rate limit для пользователя и манги.
+     *
+     * @param userId идентификатор пользователя
+     * @param mangaId идентификатор манги
+     * @param lastViewTime время последнего просмотра
+     * @return минуты до истечения rate limit, или 0 если rate limit истек
+     */
+    public long getMinutesUntilNextView(String userId, Long mangaId, LocalDateTime lastViewTime) {
+        if (lastViewTime == null) {
+            return 0;
+        }
+
+        long minutesSinceLastView = ChronoUnit.MINUTES.between(lastViewTime, LocalDateTime.now());
+        long rateLimitMinutes = 60; // 1 час rate limit
+
+        if (minutesSinceLastView >= rateLimitMinutes) {
+            return 0; // Rate limit истек
+        }
+
+        return rateLimitMinutes - minutesSinceLastView;
+    }
+}

--- a/MangaService/src/test/java/shadowshift/studio/mangaservice/service/ViewTrackingServiceTest.java
+++ b/MangaService/src/test/java/shadowshift/studio/mangaservice/service/ViewTrackingServiceTest.java
@@ -1,0 +1,83 @@
+package shadowshift.studio.mangaservice.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shadowshift.studio.mangaservice.entity.Manga;
+import shadowshift.studio.mangaservice.repository.MangaRepository;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ViewTrackingServiceTest {
+
+    @Mock
+    private MangaRepository mangaRepository;
+
+    @Mock
+    private ViewTrackingService viewTrackingService;
+
+    @InjectMocks
+    private MangaService mangaService;
+
+    @Test
+    void incrementView_ShouldIncreaseCounters() {
+        // Given
+        Long mangaId = 1L;
+        String userId = "user123";
+
+        Manga manga = new Manga();
+        manga.setId(mangaId);
+        manga.setViews(10L);
+        manga.setUniqueViews(5L);
+
+        when(mangaRepository.findById(mangaId)).thenReturn(Optional.of(manga));
+        when(viewTrackingService.canIncrementUniqueView(userId, mangaId)).thenReturn(true);
+        when(mangaRepository.save(any(Manga.class))).thenReturn(manga);
+
+        // When
+        mangaService.incrementView(mangaId, userId);
+
+        // Then
+        verify(mangaRepository).findById(mangaId);
+        verify(viewTrackingService).canIncrementUniqueView(userId, mangaId);
+        verify(mangaRepository).save(manga);
+
+        // Verify counters increased
+        assert manga.getViews() == 11L;
+        assert manga.getUniqueViews() == 6L;
+    }
+
+    @Test
+    void incrementView_ShouldHandleRateLimit() {
+        // Given
+        Long mangaId = 1L;
+        String userId = "user123";
+
+        Manga manga = new Manga();
+        manga.setId(mangaId);
+        manga.setViews(10L);
+        manga.setUniqueViews(5L);
+
+        when(mangaRepository.findById(mangaId)).thenReturn(Optional.of(manga));
+        when(viewTrackingService.canIncrementUniqueView(userId, mangaId)).thenReturn(false);
+        when(mangaRepository.save(any(Manga.class))).thenReturn(manga);
+
+        // When
+        mangaService.incrementView(mangaId, userId);
+
+        // Then
+        verify(mangaRepository).findById(mangaId);
+        verify(viewTrackingService).canIncrementUniqueView(userId, mangaId);
+        verify(mangaRepository).save(manga);
+
+        // Verify only general counter increased
+        assert manga.getViews() == 11L;
+        assert manga.getUniqueViews() == 5L; // Should not increase due to rate limit
+    }
+}


### PR DESCRIPTION
This pull request implements a comprehensive manga view tracking system, including both total and unique (rate-limited per user) view counters, and integrates these counters throughout the backend and frontend. It also introduces backend support for user authentication in view tracking and updates the UI to display these new metrics.

**Backend: Manga view tracking and security integration**

* Added `views` and `uniqueViews` fields to the `Manga` entity and `MangaResponseDTO`, with corresponding getters/setters and DTO mapping. [[1]](diffhunk://#diff-a4b39709475b90e1e8bd50900b1a5938a9e555466c4e120c3cd6d4e95ed3d6a2R132-R143) [[2]](diffhunk://#diff-a4b39709475b90e1e8bd50900b1a5938a9e555466c4e120c3cd6d4e95ed3d6a2R433-R460) [[3]](diffhunk://#diff-29ff86ee418c296586bbc47a625ef9b1a535d8f40ea204a888968d2e71dfb7f4R95-R104) [[4]](diffhunk://#diff-29ff86ee418c296586bbc47a625ef9b1a535d8f40ea204a888968d2e71dfb7f4R142-R143) [[5]](diffhunk://#diff-29ff86ee418c296586bbc47a625ef9b1a535d8f40ea204a888968d2e71dfb7f4R372-R399)
* Implemented `incrementView` logic in `MangaService` to increase both total and unique manga views, with unique views rate-limited per user using the new `ViewTrackingService`. [[1]](diffhunk://#diff-2462e39593007151d5272b871d4d337f4147fc2eb30be9d707d41c0668ec8e51R55) [[2]](diffhunk://#diff-2462e39593007151d5272b871d4d337f4147fc2eb30be9d707d41c0668ec8e51R71-R84) [[3]](diffhunk://#diff-2462e39593007151d5272b871d4d337f4147fc2eb30be9d707d41c0668ec8e51R436-R483)
* Updated REST and web controllers to increment view counters on manga access, extracting the user ID from authentication where available. (Fbbfb6f8L27R27, [[1]](diffhunk://#diff-169f0677c3242365206a2b368bf2a2ad0d8d1e5408f65e721b8e78972bb17470R201-R224) [[2]](diffhunk://#diff-c2cab2903b8f6527ca164ffeb334e02dc9a5de8793199bc50e2b1ea55299533cR152-R162) [[3]](diffhunk://#diff-c2cab2903b8f6527ca164ffeb334e02dc9a5de8793199bc50e2b1ea55299533cR329-R346)
* Added Spring Security dependency and authentication context extraction for user identification in view tracking. [[1]](diffhunk://#diff-6db371d5df13d6ccf43bc825a52ff8e93e5601ca22b6b56e84c0c59ae471351cR26) [[2]](diffhunk://#diff-c2cab2903b8f6527ca164ffeb334e02dc9a5de8793199bc50e2b1ea55299533cR6-R7)

**Frontend: Display and increment view counters**

* Updated the frontend to display both total and unique view counters in `MangaCard` and `MangaPage`, using real API data instead of random values. [[1]](diffhunk://#diff-a62092e24718fce75806d60872f1d18b8a2a347946e55635b6ee2e9d4f3351b6L30-R31) [[2]](diffhunk://#diff-a62092e24718fce75806d60872f1d18b8a2a347946e55635b6ee2e9d4f3351b6R181-R185) [[3]](diffhunk://#diff-57054746d759fcd0985bf2f6613f512b095430636afa77fd156241341f242447R211-R223)
* Added API call and React `useEffect` logic to increment the view counter when a manga page is loaded. [[1]](diffhunk://#diff-e08ab56a16f6e8d175af5770589dceab75b33eebe8c2c726fe0b256d674de194R73-R78) [[2]](diffhunk://#diff-57054746d759fcd0985bf2f6613f512b095430636afa77fd156241341f242447R52-R62)
* Extended the frontend manga DTO to include `views` and `uniqueViews`.

**Infrastructure and caching**

* Configured cache eviction for manga view updates and registered new cache names for view tracking. [[1]](diffhunk://#diff-1c344825863adef4d794e04867fe181a6618422094bc2b0e02e9518295d785f4L30-R32) [[2]](diffhunk://#diff-2462e39593007151d5272b871d4d337f4147fc2eb30be9d707d41c0668ec8e51R436-R483)

These changes enable accurate and secure tracking of manga popularity, improve the user experience by displaying real view statistics, and lay the groundwork for analytics and recommendation features.…d frontend display