### PR TITLE
refactor(markdown): enhance styling for better text wrapping and over…

### DIFF
--- a/AniWayFrontend/src/components/ReviewForm.tsx
+++ b/AniWayFrontend/src/components/ReviewForm.tsx
@@ -82,8 +82,8 @@ export const ReviewForm: React.FC<ReviewFormProps> = ({
   };
 
   return (
-    <div className="bg-white/5 backdrop-blur-md rounded-3xl p-6 shadow-lg border border-white/10">
-      <h3 className="text-xl font-bold text-white mb-6">
+    <div className="bg-white/5 backdrop-blur-md rounded-3xl p-6 shadow-lg border border-white/10 max-w-full overflow-hidden">
+      <h3 className="text-xl font-bold text-white mb-6 break-words">
         {isEditing ? 'Редактировать отзыв' : 'Написать отзыв'}
       </h3>
 
@@ -109,7 +109,9 @@ export const ReviewForm: React.FC<ReviewFormProps> = ({
         {/* Comment Section */}
         <div>
           <label className="block text-sm font-medium text-gray-200 mb-2">Комментарий</label>
-          <MarkdownEditor value={comment} onChange={setComment} placeholder="Поделитесь своими впечатлениями о манге... Используйте Markdown (жирный, курсив, спойлеры)." minRows={6} maxRows={18} />
+          <div className="w-full overflow-hidden">
+            <MarkdownEditor value={comment} onChange={setComment} placeholder="Поделитесь своими впечатлениями о манге... Используйте Markdown (жирный, курсив, спойлеры)." minRows={6} maxRows={18} />
+          </div>
           <div className="flex justify-between items-center mt-2">
             <p className="text-xs text-gray-400">Расскажите о сюжете, персонажах, рисовке...</p>
             <span className="text-xs text-gray-400">{comment.length}/2000</span>
@@ -124,7 +126,7 @@ export const ReviewForm: React.FC<ReviewFormProps> = ({
               <RatingStars rating={rating} maxRating={10} size="sm" showValue={false} />
               <span className="text-sm font-medium text-white">{rating}/10</span>
             </div>
-            <div className="text-gray-200 text-sm leading-relaxed markdown-body">
+            <div className="text-gray-200 text-sm leading-relaxed markdown-body max-w-full overflow-hidden break-words">
               <MarkdownRenderer value={comment.trim()} />
             </div>
           </div>

--- a/AniWayFrontend/src/components/markdown/MarkdownEditor.tsx
+++ b/AniWayFrontend/src/components/markdown/MarkdownEditor.tsx
@@ -69,7 +69,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange,
     </button>
   )
   return (
-    <div className={`rounded-xl border border-white/10 bg-white/5 ${compact? 'p-3':'p-4'} space-y-3`}> 
+    <div className={`rounded-xl border border-white/10 bg-white/5 ${compact? 'p-3':'p-4'} space-y-3 max-w-full overflow-hidden`}> 
       <div className="flex flex-wrap items-center gap-1">
         {toolbarBtn('Жирный', <Bold className="h-4 w-4" />, 'bold')}
         {toolbarBtn('Курсив', <Italic className="h-4 w-4" />, 'italic')}
@@ -92,7 +92,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange,
           className="w-full resize-y rounded-md bg-black/30 p-3 text-sm text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-primary/40 font-medium tracking-wide leading-relaxed" />
       )}
       {preview && (
-        <div className="prose prose-invert max-w-none text-sm leading-relaxed markdown-body">
+        <div className="prose prose-invert max-w-none text-sm leading-relaxed markdown-body max-w-full overflow-hidden break-words">
           <MarkdownRenderer value={value || '*Пусто*'} />
         </div>
       )}

--- a/AniWayFrontend/src/index.css
+++ b/AniWayFrontend/src/index.css
@@ -187,11 +187,18 @@
 }
 
 /* Markdown & Spoilers */
-.markdown-body p { margin-top: 0.5rem; margin-bottom: 0.75rem; }
+.markdown-body { 
+  word-wrap: break-word; 
+  overflow-wrap: break-word; 
+  hyphens: auto; 
+  max-width: 100%; 
+  overflow: hidden;
+}
+.markdown-body p { margin-top: 0.5rem; margin-bottom: 0.75rem; word-break: break-word; }
 .markdown-body pre { background: rgba(0,0,0,0.4); padding: 0.75rem 1rem; border-radius: 0.75rem; overflow-x: auto; font-size: 12px; }
-.markdown-body code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+.markdown-body code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; word-break: break-all; }
 .markdown-body table { width: 100%; border-collapse: collapse; font-size: 12px; }
-.markdown-body th, .markdown-body td { border: 1px solid rgba(255,255,255,0.1); padding: 4px 8px; }
+.markdown-body th, .markdown-body td { border: 1px solid rgba(255,255,255,0.1); padding: 4px 8px; word-break: break-word; }
 .markdown-body tr:nth-child(even){ background: rgba(255,255,255,0.04); }
 .spoiler { position: relative; cursor: pointer; }
 /* Hidden state */


### PR DESCRIPTION
This pull request improves the handling and display of long or unbroken text in markdown content throughout the review form and markdown editor components. The main focus is on ensuring that markdown-rendered text wraps correctly and doesn't overflow its containers, providing a better user experience when dealing with lengthy comments, code blocks, or tables.

**Styling and layout improvements for markdown content:**

* Updated the `.markdown-body` CSS class and related selectors to enforce word wrapping, hyphenation, and overflow handling, ensuring markdown content (including paragraphs, code, and tables) stays within container bounds and wraps as needed.
* Added `max-w-full`, `overflow-hidden`, and `break-words` utility classes to containers and markdown preview areas in `ReviewForm.tsx` and `MarkdownEditor.tsx` to prevent overflow and enable proper text wrapping for user comments and markdown previews. [[1]](diffhunk://#diff-9b9b242c42535e6d9675d199bc9a14dc1a130b09f5ce66a32704ffe7de737ffbL85-R86) [[2]](diffhunk://#diff-9b9b242c42535e6d9675d199bc9a14dc1a130b09f5ce66a32704ffe7de737ffbL127-R129) [[3]](diffhunk://#diff-f01adf71a3a9cd7b535dae2518429045436282f8c899c0dc1abee765a4da0334L72-R72) [[4]](diffhunk://#diff-f01adf71a3a9cd7b535dae2518429045436282f8c899c0dc1abee765a4da0334L95-R95)

**Component structure adjustments:**

* Wrapped the markdown editor in an additional container with `w-full overflow-hidden` in the review form to further constrain the editor's width and prevent layout issues with long content.…flow handling

Связанные issues: #18